### PR TITLE
refactor: deduplicate bulk types, add validation, partition store, complete edit UX

### DIFF
--- a/internal/api/handlers_bulk.go
+++ b/internal/api/handlers_bulk.go
@@ -4,48 +4,18 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/erxyi/qlx/internal/shared/dto"
 	"github.com/erxyi/qlx/internal/shared/webutil"
 )
 
-type bulkIDEntry struct {
-	ID   string `json:"id"`
-	Type string `json:"type"` // "container" or "item"
-}
-
-type bulkMoveRequest struct {
-	IDs               []bulkIDEntry `json:"ids"`
-	TargetContainerID string        `json:"target_container_id"`
-}
-
-type bulkDeleteRequest struct {
-	IDs []bulkIDEntry `json:"ids"`
-}
-
-type bulkTagsRequest struct {
-	IDs   []bulkIDEntry `json:"ids"`
-	TagID string        `json:"tag_id"`
-}
-
-func splitBulkIDs(entries []bulkIDEntry) (itemIDs, containerIDs []string) {
-	for _, e := range entries {
-		switch e.Type {
-		case "item":
-			itemIDs = append(itemIDs, e.ID)
-		case "container":
-			containerIDs = append(containerIDs, e.ID)
-		}
-	}
-	return
-}
-
 func (s *Server) HandleBulkMove(w http.ResponseWriter, r *http.Request) {
-	var req bulkMoveRequest
+	var req dto.BulkMoveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	errs, err := s.bulk.Move(itemIDs, containerIDs, req.TargetContainerID)
 	if err != nil {
 		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -55,13 +25,13 @@ func (s *Server) HandleBulkMove(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleBulkDelete(w http.ResponseWriter, r *http.Request) {
-	var req bulkDeleteRequest
+	var req dto.BulkDeleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	deleted, failed, err := s.bulk.Delete(itemIDs, containerIDs)
 	if err != nil {
 		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -74,13 +44,13 @@ func (s *Server) HandleBulkDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleBulkTags(w http.ResponseWriter, r *http.Request) {
-	var req bulkTagsRequest
+	var req dto.BulkTagsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	if err := s.bulk.AddTag(itemIDs, containerIDs, req.TagID); err != nil {
 		webutil.WriteStoreErrorJSON(w, err)
 		return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -160,14 +160,9 @@ func (s *Server) HandleContainerCreate(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&req)
 	}
 
-	if strings.TrimSpace(req.Name) == "" {
-		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
-		return
-	}
-
 	container, err := s.inventory.CreateContainer(req.ParentID, req.Name, req.Description)
 	if err != nil {
-		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		webutil.WriteStoreErrorJSON(w, err)
 		return
 	}
 	webutil.JSON(w, http.StatusCreated, container)
@@ -227,10 +222,6 @@ func (s *Server) HandleItemCreate(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&req)
 	}
 
-	if strings.TrimSpace(req.Name) == "" {
-		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
-		return
-	}
 	if req.ContainerID == "" {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "container_id is required"})
 		return
@@ -238,7 +229,7 @@ func (s *Server) HandleItemCreate(w http.ResponseWriter, r *http.Request) {
 
 	item, err := s.inventory.CreateItem(req.ContainerID, req.Name, req.Description, req.Quantity)
 	if err != nil {
-		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		webutil.WriteStoreErrorJSON(w, err)
 		return
 	}
 	webutil.JSON(w, http.StatusCreated, item)
@@ -249,11 +240,16 @@ func (s *Server) HandleItemUpdate(w http.ResponseWriter, r *http.Request) {
 		Name:        r.FormValue("name"),        //nolint:gosec // G120: internal tool, no untrusted input
 		Description: r.FormValue("description"), //nolint:gosec // G120: internal tool, no untrusted input
 	}
+	if qStr := r.FormValue("quantity"); qStr != "" { //nolint:gosec // G120: internal tool, no untrusted input
+		if q, err := strconv.Atoi(qStr); err == nil {
+			req.Quantity = q
+		}
+	}
 	if isJSONBody(r) {
 		_ = json.NewDecoder(r.Body).Decode(&req)
 	}
 
-	item, err := s.inventory.UpdateItem(r.PathValue("id"), req.Name, req.Description)
+	item, err := s.inventory.UpdateItem(r.PathValue("id"), req.Name, req.Description, req.Quantity)
 	if err != nil {
 		webutil.WriteStoreErrorJSON(w, err)
 		return

--- a/internal/embedded/static/css/layout/content.css
+++ b/internal/embedded/static/css/layout/content.css
@@ -26,6 +26,12 @@
     font-style: italic;
 }
 
+.container-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 .description {
     color: var(--color-text-muted);
 }

--- a/internal/embedded/static/css/shared/buttons.css
+++ b/internal/embedded/static/css/shared/buttons.css
@@ -80,6 +80,11 @@ a.button.secondary:hover {
     border-color: var(--color-accent);
 }
 
+a.button.small {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+}
+
 .button.primary {
     background: var(--color-success);
     color: white;

--- a/internal/embedded/static/i18n/en/inventory.json
+++ b/internal/embedded/static/i18n/en/inventory.json
@@ -29,5 +29,6 @@
   "inventory.edit_item": "Edit item",
   "inventory.new_item": "New item",
   "inventory.edit_container": "Edit container",
-  "inventory.new_container": "New container"
+  "inventory.new_container": "New container",
+  "inventory.quantity": "Quantity"
 }

--- a/internal/embedded/static/i18n/pl/inventory.json
+++ b/internal/embedded/static/i18n/pl/inventory.json
@@ -29,5 +29,6 @@
   "inventory.edit_item": "Edytuj przedmiot",
   "inventory.new_item": "Nowy przedmiot",
   "inventory.edit_container": "Edytuj kontener",
-  "inventory.new_container": "Nowy kontener"
+  "inventory.new_container": "Nowy kontener",
+  "inventory.quantity": "Ilość"
 }

--- a/internal/embedded/templates/pages/inventory/containers.html
+++ b/internal/embedded/templates/pages/inventory/containers.html
@@ -7,7 +7,10 @@
     {{ end }}
 
     {{ if .Data.Container }}
-    <h2>{{ .Data.Container.Name }}</h2>
+    <div class="container-header">
+        <h2>{{ .Data.Container.Name }}</h2>
+        <a href="/ui/containers/{{ .Data.Container.ID }}/edit" hx-get="/ui/containers/{{ .Data.Container.ID }}/edit" hx-target="#content" class="button secondary small">{{.T "inventory.edit"}}</a>
+    </div>
     {{ if .Data.Container.Description }}<p class="description">{{ .Data.Container.Description }}</p>{{ end }}
     {{ end }}
 

--- a/internal/embedded/templates/pages/inventory/item.html
+++ b/internal/embedded/templates/pages/inventory/item.html
@@ -99,7 +99,7 @@
         </section>
 
         <section class="actions">
-            <a href="/ui/items/{{ .Data.Item.ID }}" class="button">{{.T "inventory.edit"}}</a>
+            <a href="/ui/items/{{ .Data.Item.ID }}/edit" hx-get="/ui/items/{{ .Data.Item.ID }}/edit" hx-target="#content" class="button">{{.T "inventory.edit"}}</a>
             <button hx-delete="/ui/actions/items/{{ .Data.Item.ID }}" hx-target="#content" hx-confirm="{{.T "inventory.confirm_delete_item"}}" class="danger">{{.T "action.delete"}}</button>
         </section>
 

--- a/internal/embedded/templates/pages/inventory/item_form.html
+++ b/internal/embedded/templates/pages/inventory/item_form.html
@@ -13,6 +13,11 @@
         {{ template "fields/name-desc" dict "name" "" "description" "" "nameLabel" (.T "form.name") "descLabel" (.T "form.description") }}
         {{ end }}
 
+        <div class="form-group">
+            <label for="quantity">{{.T "inventory.quantity"}}</label>
+            <input type="number" id="quantity" name="quantity" value="{{ if .Data.Item }}{{ .Data.Item.Quantity }}{{ else }}1{{ end }}" min="1">
+        </div>
+
         <div class="actions">
             <button type="submit">{{ if .Data.Item }}{{.T "action.save"}}{{ else }}{{.T "inventory.create"}}{{ end }}</button>
             <a href="{{ if .Data.Item }}/ui/items/{{ .Data.Item.ID }}{{ else }}/ui/containers/{{ .Data.ContainerID }}/items{{ end }}" hx-get="{{ if .Data.Item }}/ui/items/{{ .Data.Item.ID }}{{ else }}/ui/containers/{{ .Data.ContainerID }}/items{{ end }}" hx-target="#content" class="button secondary">{{.T "action.cancel"}}</a>

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -11,7 +11,7 @@ type Saveable interface {
 type ItemStore interface {
 	GetItem(id string) *store.Item
 	CreateItem(containerID, name, desc string, qty int) *store.Item
-	UpdateItem(id, name, desc string) (*store.Item, error)
+	UpdateItem(id, name, desc string, qty int) (*store.Item, error)
 	DeleteItem(id string) error
 	MoveItem(id, containerID string) error
 }

--- a/internal/service/inventory.go
+++ b/internal/service/inventory.go
@@ -1,6 +1,9 @@
 package service
 
-import "github.com/erxyi/qlx/internal/store"
+import (
+	"github.com/erxyi/qlx/internal/shared/validate"
+	"github.com/erxyi/qlx/internal/store"
+)
 
 // InventoryService handles container and item CRUD operations,
 // calling Save() after each mutation.
@@ -47,6 +50,12 @@ func (s *InventoryService) ContainerPath(id string) []store.Container {
 
 // CreateContainer creates a new container and persists the change.
 func (s *InventoryService) CreateContainer(parentID, name, desc string) (*store.Container, error) {
+	if err := validate.Name(name, validate.MaxNameLength); err != nil {
+		return nil, err
+	}
+	if err := validate.OptionalText(desc, validate.MaxDescriptionLength); err != nil {
+		return nil, err
+	}
 	c := s.store.CreateContainer(parentID, name, desc)
 	if err := s.store.Save(); err != nil {
 		return nil, err
@@ -56,6 +65,12 @@ func (s *InventoryService) CreateContainer(parentID, name, desc string) (*store.
 
 // UpdateContainer updates a container's name and description, then persists.
 func (s *InventoryService) UpdateContainer(id, name, desc string) (*store.Container, error) {
+	if err := validate.Name(name, validate.MaxNameLength); err != nil {
+		return nil, err
+	}
+	if err := validate.OptionalText(desc, validate.MaxDescriptionLength); err != nil {
+		return nil, err
+	}
 	c, err := s.store.UpdateContainer(id, name, desc)
 	if err != nil {
 		return nil, err
@@ -93,6 +108,12 @@ func (s *InventoryService) GetItem(id string) *store.Item {
 
 // CreateItem creates a new item and persists the change.
 func (s *InventoryService) CreateItem(containerID, name, desc string, qty int) (*store.Item, error) {
+	if err := validate.Name(name, validate.MaxNameLength); err != nil {
+		return nil, err
+	}
+	if err := validate.OptionalText(desc, validate.MaxDescriptionLength); err != nil {
+		return nil, err
+	}
 	item := s.store.CreateItem(containerID, name, desc, qty)
 	if err := s.store.Save(); err != nil {
 		return nil, err
@@ -100,9 +121,16 @@ func (s *InventoryService) CreateItem(containerID, name, desc string, qty int) (
 	return item, nil
 }
 
-// UpdateItem updates an item's name and description, then persists.
-func (s *InventoryService) UpdateItem(id, name, desc string) (*store.Item, error) {
-	item, err := s.store.UpdateItem(id, name, desc)
+// UpdateItem updates an item's name, description, and quantity, then persists.
+// If qty is less than 1, the existing quantity is preserved.
+func (s *InventoryService) UpdateItem(id, name, desc string, qty int) (*store.Item, error) {
+	if err := validate.Name(name, validate.MaxNameLength); err != nil {
+		return nil, err
+	}
+	if err := validate.OptionalText(desc, validate.MaxDescriptionLength); err != nil {
+		return nil, err
+	}
+	item, err := s.store.UpdateItem(id, name, desc, qty)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/inventory_test.go
+++ b/internal/service/inventory_test.go
@@ -19,7 +19,7 @@ type mockInventoryStore struct {
 	containerPath     func(id string) []store.Container
 	getItem           func(id string) *store.Item
 	createItem        func(containerID, name, desc string, qty int) *store.Item
-	updateItem        func(id, name, desc string) (*store.Item, error)
+	updateItem        func(id, name, desc string, qty int) (*store.Item, error)
 	deleteItem        func(id string) error
 	moveItem          func(id, containerID string) error
 	save              func() error
@@ -85,11 +85,11 @@ func (m *mockInventoryStore) CreateItem(containerID, name, desc string, qty int)
 	}
 	return &store.Item{ID: "i1", Name: name}
 }
-func (m *mockInventoryStore) UpdateItem(id, name, desc string) (*store.Item, error) {
+func (m *mockInventoryStore) UpdateItem(id, name, desc string, qty int) (*store.Item, error) {
 	if m.updateItem != nil {
-		return m.updateItem(id, name, desc)
+		return m.updateItem(id, name, desc, qty)
 	}
-	return &store.Item{ID: id, Name: name}, nil
+	return &store.Item{ID: id, Name: name, Quantity: qty}, nil
 }
 func (m *mockInventoryStore) DeleteItem(id string) error {
 	if m.deleteItem != nil {

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -1,6 +1,9 @@
 package service
 
-import "github.com/erxyi/qlx/internal/store"
+import (
+	"github.com/erxyi/qlx/internal/shared/validate"
+	"github.com/erxyi/qlx/internal/store"
+)
 
 // TagService handles tag CRUD and tag assignment operations,
 // calling Save() after each mutation.
@@ -54,6 +57,9 @@ func (s *TagService) TagDescendants(id string) []string {
 
 // CreateTag creates a new tag and persists.
 func (s *TagService) CreateTag(parentID, name string) (*store.Tag, error) {
+	if err := validate.Name(name, validate.MaxTagNameLength); err != nil {
+		return nil, err
+	}
 	t := s.store.CreateTag(parentID, name)
 	if err := s.store.Save(); err != nil {
 		return nil, err
@@ -63,6 +69,9 @@ func (s *TagService) CreateTag(parentID, name string) (*store.Tag, error) {
 
 // UpdateTag updates a tag's name and persists.
 func (s *TagService) UpdateTag(id, name string) (*store.Tag, error) {
+	if err := validate.Name(name, validate.MaxTagNameLength); err != nil {
+		return nil, err
+	}
 	t, err := s.store.UpdateTag(id, name)
 	if err != nil {
 		return nil, err

--- a/internal/service/tags_test.go
+++ b/internal/service/tags_test.go
@@ -25,7 +25,7 @@ type mockTagStore struct {
 	// ItemStore + ContainerStore (needed by TagService's store interface)
 	getItem           func(id string) *store.Item
 	createItem        func(containerID, name, desc string, qty int) *store.Item
-	updateItem        func(id, name, desc string) (*store.Item, error)
+	updateItem        func(id, name, desc string, qty int) (*store.Item, error)
 	deleteItem        func(id string) error
 	moveItem          func(id, containerID string) error
 	getContainer      func(id string) *store.Container
@@ -130,11 +130,11 @@ func (m *mockTagStore) CreateItem(containerID, name, desc string, qty int) *stor
 	}
 	return &store.Item{ID: "i1", Name: name}
 }
-func (m *mockTagStore) UpdateItem(id, name, desc string) (*store.Item, error) {
+func (m *mockTagStore) UpdateItem(id, name, desc string, qty int) (*store.Item, error) {
 	if m.updateItem != nil {
-		return m.updateItem(id, name, desc)
+		return m.updateItem(id, name, desc, qty)
 	}
-	return &store.Item{ID: id, Name: name}, nil
+	return &store.Item{ID: id, Name: name, Quantity: qty}, nil
 }
 func (m *mockTagStore) DeleteItem(id string) error {
 	if m.deleteItem != nil {

--- a/internal/shared/dto/bulk.go
+++ b/internal/shared/dto/bulk.go
@@ -1,0 +1,37 @@
+package dto
+
+// BulkIDEntry identifies a single entity in a bulk operation.
+type BulkIDEntry struct {
+	ID   string `json:"id"`
+	Type string `json:"type"` // "container" or "item"
+}
+
+// BulkMoveRequest is the request body for bulk move operations.
+type BulkMoveRequest struct {
+	IDs               []BulkIDEntry `json:"ids"`
+	TargetContainerID string        `json:"target_container_id"`
+}
+
+// BulkDeleteRequest is the request body for bulk delete operations.
+type BulkDeleteRequest struct {
+	IDs []BulkIDEntry `json:"ids"`
+}
+
+// BulkTagsRequest is the request body for bulk tag operations.
+type BulkTagsRequest struct {
+	IDs   []BulkIDEntry `json:"ids"`
+	TagID string        `json:"tag_id"`
+}
+
+// SplitBulkIDs separates a slice of BulkIDEntry into item IDs and container IDs.
+func SplitBulkIDs(entries []BulkIDEntry) (itemIDs, containerIDs []string) {
+	for _, e := range entries {
+		switch e.Type {
+		case "item":
+			itemIDs = append(itemIDs, e.ID)
+		case "container":
+			containerIDs = append(containerIDs, e.ID)
+		}
+	}
+	return
+}

--- a/internal/shared/dto/bulk_test.go
+++ b/internal/shared/dto/bulk_test.go
@@ -1,0 +1,85 @@
+package dto
+
+import (
+	"testing"
+)
+
+func TestSplitBulkIDs(t *testing.T) {
+	tests := []struct {
+		name         string
+		entries      []BulkIDEntry
+		wantItems    []string
+		wantContains []string
+	}{
+		{
+			name:         "empty",
+			entries:      nil,
+			wantItems:    nil,
+			wantContains: nil,
+		},
+		{
+			name: "items only",
+			entries: []BulkIDEntry{
+				{ID: "i1", Type: "item"},
+				{ID: "i2", Type: "item"},
+			},
+			wantItems:    []string{"i1", "i2"},
+			wantContains: nil,
+		},
+		{
+			name: "containers only",
+			entries: []BulkIDEntry{
+				{ID: "c1", Type: "container"},
+			},
+			wantItems:    nil,
+			wantContains: []string{"c1"},
+		},
+		{
+			name: "mixed",
+			entries: []BulkIDEntry{
+				{ID: "i1", Type: "item"},
+				{ID: "c1", Type: "container"},
+				{ID: "i2", Type: "item"},
+				{ID: "c2", Type: "container"},
+			},
+			wantItems:    []string{"i1", "i2"},
+			wantContains: []string{"c1", "c2"},
+		},
+		{
+			name: "unknown type ignored",
+			entries: []BulkIDEntry{
+				{ID: "x1", Type: "unknown"},
+				{ID: "i1", Type: "item"},
+			},
+			wantItems:    []string{"i1"},
+			wantContains: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotItems, gotContains := SplitBulkIDs(tt.entries)
+			if !sliceEqual(gotItems, tt.wantItems) {
+				t.Errorf("items = %v, want %v", gotItems, tt.wantItems)
+			}
+			if !sliceEqual(gotContains, tt.wantContains) {
+				t.Errorf("containers = %v, want %v", gotContains, tt.wantContains)
+			}
+		})
+	}
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/shared/validate/validate.go
+++ b/internal/shared/validate/validate.go
@@ -1,0 +1,71 @@
+// Package validate provides input validation for entity names and descriptions.
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const (
+	// MaxNameLength is the maximum allowed length for container and item names.
+	MaxNameLength = 100
+	// MaxDescriptionLength is the maximum allowed length for descriptions.
+	MaxDescriptionLength = 500
+	// MaxTagNameLength is the maximum allowed length for tag names.
+	MaxTagNameLength = 50
+)
+
+var (
+	// ErrNameRequired indicates a required name field was empty.
+	ErrNameRequired = errors.New("name is required")
+	// ErrNameTooLong indicates the name exceeds the maximum length.
+	ErrNameTooLong = errors.New("name exceeds maximum length")
+	// ErrDescriptionTooLong indicates the description exceeds the maximum length.
+	ErrDescriptionTooLong = errors.New("description exceeds maximum length")
+	// ErrInvalidCharacters indicates the text contains control characters.
+	ErrInvalidCharacters = errors.New("contains invalid characters")
+)
+
+// Name validates a required name field: must be non-empty after trimming,
+// within maxLen characters, and free of control characters (tabs allowed).
+func Name(name string, maxLen int) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return ErrNameRequired
+	}
+	if len(trimmed) > maxLen {
+		return fmt.Errorf("%w: %d (max %d)", ErrNameTooLong, len(trimmed), maxLen)
+	}
+	if containsControlChars(trimmed) {
+		return ErrInvalidCharacters
+	}
+	return nil
+}
+
+// OptionalText validates an optional text field: max length and no control characters.
+// Empty strings are valid.
+func OptionalText(text string, maxLen int) error {
+	if text == "" {
+		return nil
+	}
+	if len(text) > maxLen {
+		return fmt.Errorf("%w: %d (max %d)", ErrDescriptionTooLong, len(text), maxLen)
+	}
+	if containsControlChars(text) {
+		return ErrInvalidCharacters
+	}
+	return nil
+}
+
+// containsControlChars returns true if s contains any Unicode control character
+// other than tab (\t) and newline (\n).
+func containsControlChars(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) && r != '\t' && r != '\n' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/shared/validate/validate_test.go
+++ b/internal/shared/validate/validate_test.go
@@ -1,0 +1,78 @@
+package validate
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		maxLen  int
+		wantErr error
+	}{
+		{"valid short name", "Box A", 100, nil},
+		{"empty", "", 100, ErrNameRequired},
+		{"whitespace only", "   ", 100, ErrNameRequired},
+		{"tab only", "\t", 100, ErrNameRequired},
+		{"exactly at limit", strings.Repeat("a", 100), 100, nil},
+		{"one over limit", strings.Repeat("a", 101), 100, ErrNameTooLong},
+		{"way over limit", strings.Repeat("x", 200), 50, ErrNameTooLong},
+		{"contains null byte", "hello\x00world", 100, ErrInvalidCharacters},
+		{"contains carriage return", "hello\rworld", 100, ErrInvalidCharacters},
+		{"tab allowed", "hello\tworld", 100, nil},
+		{"newline allowed in name", "hello\nworld", 100, nil},
+		{"unicode name", "Półka Główna", 100, nil},
+		{"emoji name", "📦 Box", 100, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Name(tt.input, tt.maxLen)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("Name(%q, %d) = %v, want nil", tt.input, tt.maxLen, err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Name(%q, %d) = %v, want %v", tt.input, tt.maxLen, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOptionalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		maxLen  int
+		wantErr error
+	}{
+		{"empty is valid", "", 500, nil},
+		{"valid text", "A nice description", 500, nil},
+		{"exactly at limit", strings.Repeat("b", 500), 500, nil},
+		{"one over limit", strings.Repeat("b", 501), 500, ErrDescriptionTooLong},
+		{"contains null byte", "desc\x00ription", 500, ErrInvalidCharacters},
+		{"tab allowed", "desc\twith\ttabs", 500, nil},
+		{"newline allowed", "line1\nline2", 500, nil},
+		{"unicode text", "Opis z polskimi znakami: ąćęłńóśźż", 500, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := OptionalText(tt.input, tt.maxLen)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("OptionalText(%q, %d) = %v, want nil", tt.input, tt.maxLen, err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("OptionalText(%q, %d) = %v, want %v", tt.input, tt.maxLen, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/shared/webutil/errors.go
+++ b/internal/shared/webutil/errors.go
@@ -4,20 +4,25 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/erxyi/qlx/internal/shared/validate"
 	"github.com/erxyi/qlx/internal/store"
 )
 
 var statusMap = map[error]int{
-	store.ErrContainerNotFound:    http.StatusNotFound,
-	store.ErrItemNotFound:         http.StatusNotFound,
-	store.ErrTagNotFound:          http.StatusNotFound,
-	store.ErrPrinterNotFound:      http.StatusNotFound,
-	store.ErrContainerHasChildren: http.StatusConflict,
-	store.ErrContainerHasItems:    http.StatusConflict,
-	store.ErrTagHasChildren:       http.StatusConflict,
-	store.ErrCycleDetected:        http.StatusBadRequest,
-	store.ErrInvalidParent:        http.StatusBadRequest,
-	store.ErrInvalidContainer:     http.StatusBadRequest,
+	store.ErrContainerNotFound:     http.StatusNotFound,
+	store.ErrItemNotFound:          http.StatusNotFound,
+	store.ErrTagNotFound:           http.StatusNotFound,
+	store.ErrPrinterNotFound:       http.StatusNotFound,
+	store.ErrContainerHasChildren:  http.StatusConflict,
+	store.ErrContainerHasItems:     http.StatusConflict,
+	store.ErrTagHasChildren:        http.StatusConflict,
+	store.ErrCycleDetected:         http.StatusBadRequest,
+	store.ErrInvalidParent:         http.StatusBadRequest,
+	store.ErrInvalidContainer:      http.StatusBadRequest,
+	validate.ErrNameRequired:       http.StatusBadRequest,
+	validate.ErrNameTooLong:        http.StatusBadRequest,
+	validate.ErrDescriptionTooLong: http.StatusBadRequest,
+	validate.ErrInvalidCharacters:  http.StatusBadRequest,
 }
 
 // StoreHTTPStatus maps a store error to an HTTP status code.

--- a/internal/store/bulk.go
+++ b/internal/store/bulk.go
@@ -35,6 +35,7 @@ func (s *Store) moveItemsLocked(ids []string, targetContainerID string) []BulkEr
 		}
 		item.ContainerID = targetContainerID
 	}
+	s.dirty |= dirtyItems
 	return errs
 }
 
@@ -99,6 +100,7 @@ func (s *Store) moveContainersLocked(ids []string, targetParentID string) []Bulk
 	for _, id := range ids {
 		s.containers[id].ParentID = targetParentID
 	}
+	s.dirty |= dirtyContainers
 	return nil
 }
 
@@ -159,6 +161,9 @@ func (s *Store) deleteItemsLocked(ids []string) ([]string, []BulkError) {
 		delete(s.items, id)
 		deleted = append(deleted, id)
 	}
+	if len(deleted) > 0 {
+		s.dirty |= dirtyItems
+	}
 	return deleted, errs
 }
 
@@ -211,6 +216,9 @@ func (s *Store) deleteContainersLocked(ids []string) ([]string, []BulkError) {
 
 		delete(s.containers, id)
 		deleted = append(deleted, id)
+	}
+	if len(deleted) > 0 {
+		s.dirty |= dirtyContainers
 	}
 	return deleted, errs
 }
@@ -270,6 +278,7 @@ func (s *Store) BulkAddTag(itemIDs, containerIDs []string, tagID string) error {
 		}
 		if !containsString(item.TagIDs, tagID) {
 			item.TagIDs = append(item.TagIDs, tagID)
+			s.dirty |= dirtyItems
 		}
 	}
 
@@ -280,6 +289,7 @@ func (s *Store) BulkAddTag(itemIDs, containerIDs []string, tagID string) error {
 		}
 		if !containsString(c.TagIDs, tagID) {
 			c.TagIDs = append(c.TagIDs, tagID)
+			s.dirty |= dirtyContainers
 		}
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -22,6 +23,7 @@ var (
 	ErrPrinterNotFound      = errors.New("printer not found")
 )
 
+// storeData is the legacy monolithic serialization format (V1).
 type storeData struct {
 	Version    int                       `json:"version"`
 	Containers map[string]*Container     `json:"containers"`
@@ -32,10 +34,24 @@ type storeData struct {
 	Tags       map[string]*Tag           `json:"tags"`
 }
 
+// collectionFlag is a bitmask identifying which collections have been modified.
+type collectionFlag uint8
+
+const (
+	dirtyContainers collectionFlag = 1 << iota
+	dirtyItems
+	dirtyPrinters
+	dirtyTemplates
+	dirtyAssets
+	dirtyTags
+)
+
+// Store is the in-memory data store with disk persistence.
 type Store struct {
 	mu         sync.RWMutex
-	path       string
+	dataDir    string // directory for partitioned files (empty for MemoryStore)
 	assetsDir  string
+	dirty      collectionFlag
 	containers map[string]*Container
 	items      map[string]*Item
 	printers   map[string]*PrinterConfig
@@ -44,9 +60,22 @@ type Store struct {
 	tags       map[string]*Tag
 }
 
-// loadStoreData reads path, runs pending migrations, and returns a storeData.
+// collectionFiles maps dirty flags to their partition filenames.
+var collectionFiles = []struct {
+	flag collectionFlag
+	name string
+}{
+	{dirtyContainers, "containers.json"},
+	{dirtyItems, "items.json"},
+	{dirtyPrinters, "printers.json"},
+	{dirtyTemplates, "templates.json"},
+	{dirtyAssets, "assets.json"},
+	{dirtyTags, "tags.json"},
+}
+
+// loadLegacyData reads a monolithic data.json, runs pending migrations, and returns a storeData.
 // Returns nil, nil when the file does not exist or is empty.
-func loadStoreData(path string) (*storeData, error) {
+func loadLegacyData(path string) (*storeData, error) {
 	raw, fileVersion, err := loadRaw(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -88,10 +117,51 @@ func migrateIfNeeded(path string, raw map[string]any, fileVersion int) ([]byte, 
 	return json.Marshal(raw)
 }
 
+// loadPartitionedData loads collections from individual JSON files in dataDir.
+func loadPartitionedData(dataDir string) (*storeData, error) {
+	d := &storeData{}
+
+	type target struct {
+		name string
+		dest any
+	}
+	targets := []target{
+		{"containers.json", &d.Containers},
+		{"items.json", &d.Items},
+		{"printers.json", &d.Printers},
+		{"templates.json", &d.Templates},
+		{"assets.json", &d.Assets},
+		{"tags.json", &d.Tags},
+	}
+
+	for _, t := range targets {
+		path := filepath.Join(dataDir, t.name)
+		//nolint:gosec // G304: path from trusted CLI input
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(raw, t.dest); err != nil {
+			return nil, fmt.Errorf("loading %s: %w", t.name, err)
+		}
+	}
+
+	return d, nil
+}
+
+// NewStore creates a new disk-backed store. The path argument is the legacy data.json path;
+// the directory containing it becomes the data directory for partitioned files.
 func NewStore(path string) (*Store, error) {
-	assetsDir := filepath.Join(filepath.Dir(path), "assets")
+	dataDir := filepath.Dir(path)
+	assetsDir := filepath.Join(dataDir, "assets")
 	s := &Store{
-		path:       path,
+		dataDir:    dataDir,
 		assetsDir:  assetsDir,
 		containers: make(map[string]*Container),
 		items:      make(map[string]*Item),
@@ -101,68 +171,143 @@ func NewStore(path string) (*Store, error) {
 		tags:       make(map[string]*Tag),
 	}
 
-	d, err := loadStoreData(path)
-	if err != nil {
-		return nil, err
+	metaPath := filepath.Join(dataDir, "meta.json")
+	if _, err := os.Stat(metaPath); err == nil {
+		// Partitioned format: load individual collection files.
+		d, err := loadPartitionedData(dataDir)
+		if err != nil {
+			return nil, err
+		}
+		s.applyStoreData(d)
+		return s, nil
 	}
 
-	if d != nil {
-		if d.Containers != nil {
-			s.containers = d.Containers
+	// Check if legacy monolithic file exists.
+	if _, err := os.Stat(path); err == nil {
+		// Legacy monolithic format: load, migrate, then write partitioned.
+		d, err := loadLegacyData(path)
+		if err != nil {
+			return nil, err
 		}
-		if d.Items != nil {
-			s.items = d.Items
+
+		if d != nil {
+			s.applyStoreData(d)
+
+			// Migrate to partitioned format.
+			if err := s.writeAllPartitions(); err != nil {
+				return nil, fmt.Errorf("migrating to partitioned format: %w", err)
+			}
+			if err := writeAtomic(metaPath, []byte(`{"format":"partitioned","schema_version":1}`)); err != nil {
+				return nil, err
+			}
+			// Back up the legacy file.
+			backupPath := path + ".migrated"
+			_ = os.Rename(path, backupPath)
 		}
-		if d.Printers != nil {
-			s.printers = d.Printers
-		}
-		if d.Templates != nil {
-			s.templates = d.Templates
-		}
-		if d.Assets != nil {
-			s.assets = d.Assets
-		}
-		if d.Tags != nil {
-			s.tags = d.Tags
-		}
+	}
+
+	// Ensure meta.json exists for new stores so subsequent loads use partitioned format.
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		//nolint:gosec // G301: intentional permissions for data directory
+		_ = os.MkdirAll(dataDir, 0755)
+		_ = writeAtomic(metaPath, []byte(`{"format":"partitioned","schema_version":1}`))
 	}
 
 	return s, nil
 }
 
-func (s *Store) Save() error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// applyStoreData populates the store from loaded data.
+func (s *Store) applyStoreData(d *storeData) {
+	if d.Containers != nil {
+		s.containers = d.Containers
+	}
+	if d.Items != nil {
+		s.items = d.Items
+	}
+	if d.Printers != nil {
+		s.printers = d.Printers
+	}
+	if d.Templates != nil {
+		s.templates = d.Templates
+	}
+	if d.Assets != nil {
+		s.assets = d.Assets
+	}
+	if d.Tags != nil {
+		s.tags = d.Tags
+	}
+}
 
-	if s.path == "" {
+// Save writes only the modified collections to their individual JSON files.
+func (s *Store) Save() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.dirty == 0 {
 		return nil
 	}
 
 	//nolint:gosec // G301: intentional permissions for data directory
-	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+	if err := os.MkdirAll(s.dataDir, 0755); err != nil {
 		return err
 	}
 
-	data, err := json.Marshal(&storeData{
-		Version:    currentVersion,
-		Containers: s.containers,
-		Items:      s.items,
-		Printers:   s.printers,
-		Templates:  s.templates,
-		Assets:     s.assets,
-		Tags:       s.tags,
-	})
-	if err != nil {
+	collectionData := map[collectionFlag]any{
+		dirtyContainers: s.containers,
+		dirtyItems:      s.items,
+		dirtyPrinters:   s.printers,
+		dirtyTemplates:  s.templates,
+		dirtyAssets:     s.assets,
+		dirtyTags:       s.tags,
+	}
+
+	for _, cf := range collectionFiles {
+		if s.dirty&cf.flag == 0 {
+			continue
+		}
+		data, err := json.Marshal(collectionData[cf.flag])
+		if err != nil {
+			return err
+		}
+		if err := writeAtomic(filepath.Join(s.dataDir, cf.name), data); err != nil {
+			return err
+		}
+	}
+
+	s.dirty = 0
+	return nil
+}
+
+// writeAllPartitions writes all collections to partitioned files (used during migration).
+func (s *Store) writeAllPartitions() error {
+	//nolint:gosec // G301: intentional permissions for data directory
+	if err := os.MkdirAll(s.dataDir, 0755); err != nil {
 		return err
 	}
 
-	tmpPath := s.path + ".tmp"
-	//nolint:gosec // G306: intentional permissions for data file
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return err
+	collectionData := map[collectionFlag]any{
+		dirtyContainers: s.containers,
+		dirtyItems:      s.items,
+		dirtyPrinters:   s.printers,
+		dirtyTemplates:  s.templates,
+		dirtyAssets:     s.assets,
+		dirtyTags:       s.tags,
 	}
 
-	return os.Rename(tmpPath, s.path)
+	for _, cf := range collectionFiles {
+		data, err := json.Marshal(collectionData[cf.flag])
+		if err != nil {
+			return err
+		}
+		if err := writeAtomic(filepath.Join(s.dataDir, cf.name), data); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) CreateContainer(parentID, name, description string) *Container {
@@ -178,6 +323,7 @@ func (s *Store) CreateContainer(parentID, name, description string) *Container {
 		TagIDs:      []string{},
 	}
 	s.containers[c.ID] = c
+	s.dirty |= dirtyContainers
 	return c
 }
 
@@ -198,6 +344,7 @@ func (s *Store) UpdateContainer(id, name, description string) (*Container, error
 
 	c.Name = name
 	c.Description = description
+	s.dirty |= dirtyContainers
 	return c, nil
 }
 
@@ -222,6 +369,7 @@ func (s *Store) DeleteContainer(id string) error {
 	}
 
 	delete(s.containers, id)
+	s.dirty |= dirtyContainers
 	return nil
 }
 
@@ -244,6 +392,7 @@ func (s *Store) CreateItem(containerID, name, description string, quantity int) 
 		TagIDs:      []string{},
 	}
 	s.items[item.ID] = item
+	s.dirty |= dirtyItems
 	return item
 }
 
@@ -253,7 +402,9 @@ func (s *Store) GetItem(id string) *Item {
 	return s.items[id]
 }
 
-func (s *Store) UpdateItem(id, name, description string) (*Item, error) {
+// UpdateItem updates an item's name, description, and quantity. If quantity is less than 1
+// the existing quantity is preserved.
+func (s *Store) UpdateItem(id, name, description string, quantity int) (*Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -264,6 +415,10 @@ func (s *Store) UpdateItem(id, name, description string) (*Item, error) {
 
 	item.Name = name
 	item.Description = description
+	if quantity >= 1 {
+		item.Quantity = quantity
+	}
+	s.dirty |= dirtyItems
 	return item, nil
 }
 
@@ -276,6 +431,7 @@ func (s *Store) DeleteItem(id string) error {
 	}
 
 	delete(s.items, id)
+	s.dirty |= dirtyItems
 	return nil
 }
 
@@ -337,6 +493,7 @@ func (s *Store) MoveItem(itemID, newContainerID string) error {
 	}
 
 	item.ContainerID = newContainerID
+	s.dirty |= dirtyItems
 	return nil
 }
 
@@ -368,6 +525,7 @@ func (s *Store) MoveContainer(containerID, newParentID string) error {
 	}
 
 	container.ParentID = newParentID
+	s.dirty |= dirtyContainers
 	return nil
 }
 
@@ -395,6 +553,7 @@ func (s *Store) AddPrinter(name, encoder, model, transport, address string) *Pri
 		Address:   address,
 	}
 	s.printers[p.ID] = p
+	s.dirty |= dirtyPrinters
 	return p
 }
 
@@ -413,6 +572,7 @@ func (s *Store) DeletePrinter(id string) error {
 	}
 
 	delete(s.printers, id)
+	s.dirty |= dirtyPrinters
 	return nil
 }
 
@@ -487,6 +647,7 @@ func (s *Store) CreateTemplate(name string, tags []string, target string, widthM
 		UpdatedAt: now,
 	}
 	s.templates[t.ID] = t
+	s.dirty |= dirtyTemplates
 	return t
 }
 
@@ -513,6 +674,7 @@ func (s *Store) SaveTemplate(t Template) {
 
 	t.UpdatedAt = time.Now()
 	s.templates[t.ID] = &t
+	s.dirty |= dirtyTemplates
 }
 
 func (s *Store) DeleteTemplate(id string) {
@@ -520,6 +682,7 @@ func (s *Store) DeleteTemplate(id string) {
 	defer s.mu.Unlock()
 
 	delete(s.templates, id)
+	s.dirty |= dirtyTemplates
 }
 
 func (s *Store) SaveAsset(name, mimeType string, data []byte) (*Asset, error) {
@@ -545,6 +708,7 @@ func (s *Store) SaveAsset(name, mimeType string, data []byte) (*Asset, error) {
 	}
 
 	s.assets[a.ID] = a
+	s.dirty |= dirtyAssets
 	return a, nil
 }
 
@@ -576,6 +740,7 @@ func (s *Store) DeleteAsset(id string) {
 
 	_ = os.Remove(filepath.Join(s.assetsDir, id+".bin"))
 	delete(s.assets, id)
+	s.dirty |= dirtyAssets
 }
 
 func (s *Store) AllAssets() []Asset {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -117,12 +117,24 @@ func TestItemCRUD(t *testing.T) {
 		t.Errorf("GetItem Name = %q, want %q", got.Name, "Cable")
 	}
 
-	updated, err := s.UpdateItem(item.ID, "HDMI Cable", "2m HDMI cable")
+	updated, err := s.UpdateItem(item.ID, "HDMI Cable", "2m HDMI cable", 5)
 	if err != nil {
 		t.Fatalf("UpdateItem error = %v", err)
 	}
 	if updated.Name != "HDMI Cable" {
 		t.Errorf("UpdateItem Name = %q, want %q", updated.Name, "HDMI Cable")
+	}
+	if updated.Quantity != 5 {
+		t.Errorf("UpdateItem Quantity = %d, want 5", updated.Quantity)
+	}
+
+	// Quantity 0 should preserve existing value.
+	preserved, err := s.UpdateItem(item.ID, "HDMI Cable", "2m HDMI cable", 0)
+	if err != nil {
+		t.Fatalf("UpdateItem preserve qty error = %v", err)
+	}
+	if preserved.Quantity != 5 {
+		t.Errorf("UpdateItem preserved Quantity = %d, want 5", preserved.Quantity)
 	}
 
 	if err := s.DeleteItem(item.ID); err != nil {
@@ -132,7 +144,7 @@ func TestItemCRUD(t *testing.T) {
 		t.Error("DeleteItem should remove item")
 	}
 
-	_, err = s.UpdateItem("nonexistent", "Name", "")
+	_, err = s.UpdateItem("nonexistent", "Name", "", 1)
 	if !errors.Is(err, ErrItemNotFound) {
 		t.Errorf("UpdateItem error = %v, want ErrItemNotFound", err)
 	}

--- a/internal/store/tags.go
+++ b/internal/store/tags.go
@@ -25,6 +25,7 @@ func (s *Store) CreateTag(parentID, name string) *Tag {
 		CreatedAt: time.Now(),
 	}
 	s.tags[t.ID] = t
+	s.dirty |= dirtyTags
 	return t
 }
 
@@ -52,6 +53,7 @@ func (s *Store) UpdateTag(id, name string) (*Tag, error) {
 	}
 
 	t.Name = name
+	s.dirty |= dirtyTags
 	copy := *t
 	return &copy, nil
 }
@@ -73,14 +75,17 @@ func (s *Store) DeleteTag(id string) error {
 	}
 
 	delete(s.tags, id)
+	s.dirty |= dirtyTags
 
 	for _, item := range s.items {
 		item.TagIDs = removeFromSlice(item.TagIDs, id)
 	}
+	s.dirty |= dirtyItems
 
 	for _, c := range s.containers {
 		c.TagIDs = removeFromSlice(c.TagIDs, id)
 	}
+	s.dirty |= dirtyContainers
 
 	return nil
 }
@@ -186,6 +191,7 @@ func (s *Store) MoveTag(tagID, newParentID string) error {
 	}
 
 	tag.ParentID = newParentID
+	s.dirty |= dirtyTags
 	return nil
 }
 
@@ -208,6 +214,7 @@ func (s *Store) AddItemTag(itemID, tagID string) error {
 	}
 
 	item.TagIDs = append(item.TagIDs, tagID)
+	s.dirty |= dirtyItems
 	return nil
 }
 
@@ -222,6 +229,7 @@ func (s *Store) RemoveItemTag(itemID, tagID string) error {
 	}
 
 	item.TagIDs = removeFromSlice(item.TagIDs, tagID)
+	s.dirty |= dirtyItems
 	return nil
 }
 
@@ -244,6 +252,7 @@ func (s *Store) AddContainerTag(containerID, tagID string) error {
 	}
 
 	c.TagIDs = append(c.TagIDs, tagID)
+	s.dirty |= dirtyContainers
 	return nil
 }
 
@@ -258,6 +267,7 @@ func (s *Store) RemoveContainerTag(containerID, tagID string) error {
 	}
 
 	c.TagIDs = removeFromSlice(c.TagIDs, tagID)
+	s.dirty |= dirtyContainers
 	return nil
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -38,14 +38,9 @@ func (s *Server) HandleContainerCreate(w http.ResponseWriter, r *http.Request) {
 	name := r.FormValue("name")               //nolint:gosec // G120: internal tool, no untrusted input
 	description := r.FormValue("description") //nolint:gosec // G120: internal tool, no untrusted input
 
-	if strings.TrimSpace(name) == "" {
-		http.Error(w, "name is required", http.StatusBadRequest)
-		return
-	}
-
 	container, err := s.inventory.CreateContainer(parentID, name, description)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		webutil.WriteStoreErrorText(w, err)
 		return
 	}
 
@@ -101,6 +96,38 @@ func (s *Server) HandleItem(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "item", data)
 }
 
+// HandleContainerEdit serves the container edit form.
+func (s *Server) HandleContainerEdit(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	container := s.inventory.GetContainer(id)
+	if container == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := ContainerFormData{
+		Container: container,
+		Path:      s.inventory.ContainerPath(id),
+	}
+	s.render(w, r, "container-form", data)
+}
+
+// HandleItemEdit serves the item edit form.
+func (s *Server) HandleItemEdit(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	item := s.inventory.GetItem(id)
+	if item == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := ItemFormData{
+		Item: item,
+		Path: s.inventory.ContainerPath(item.ContainerID),
+	}
+	s.render(w, r, "item-form", data)
+}
+
 func (s *Server) HandleItemCreate(w http.ResponseWriter, r *http.Request) {
 	containerID := r.FormValue("container_id") //nolint:gosec // G120: internal tool, no untrusted input
 	name := r.FormValue("name")                //nolint:gosec // G120: internal tool, no untrusted input
@@ -112,10 +139,6 @@ func (s *Server) HandleItemCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if strings.TrimSpace(name) == "" {
-		http.Error(w, "name is required", http.StatusBadRequest)
-		return
-	}
 	if containerID == "" {
 		http.Error(w, "container_id is required", http.StatusBadRequest)
 		return
@@ -123,7 +146,7 @@ func (s *Server) HandleItemCreate(w http.ResponseWriter, r *http.Request) {
 
 	item, err := s.inventory.CreateItem(containerID, name, description, quantity)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		webutil.WriteStoreErrorText(w, err)
 		return
 	}
 
@@ -145,8 +168,14 @@ func (s *Server) HandleItemUpdate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	name := r.FormValue("name")               //nolint:gosec // G120: internal tool, no untrusted input
 	description := r.FormValue("description") //nolint:gosec // G120: internal tool, no untrusted input
+	quantity := 0
+	if qStr := r.FormValue("quantity"); qStr != "" { //nolint:gosec // G120: internal tool, no untrusted input
+		if q, err := strconv.Atoi(qStr); err == nil {
+			quantity = q
+		}
+	}
 
-	item, err := s.inventory.UpdateItem(id, name, description)
+	item, err := s.inventory.UpdateItem(id, name, description, quantity)
 	if err != nil {
 		webutil.WriteStoreErrorText(w, err)
 		return

--- a/internal/ui/handlers_bulk.go
+++ b/internal/ui/handlers_bulk.go
@@ -4,49 +4,19 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/erxyi/qlx/internal/shared/dto"
 	"github.com/erxyi/qlx/internal/shared/webutil"
 )
 
-type bulkIDEntry struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
-
-type bulkMoveRequest struct {
-	IDs               []bulkIDEntry `json:"ids"`
-	TargetContainerID string        `json:"target_container_id"`
-}
-
-type bulkDeleteRequest struct {
-	IDs []bulkIDEntry `json:"ids"`
-}
-
-type bulkTagsRequest struct {
-	IDs   []bulkIDEntry `json:"ids"`
-	TagID string        `json:"tag_id"`
-}
-
-func splitBulkIDs(entries []bulkIDEntry) (itemIDs, containerIDs []string) {
-	for _, e := range entries {
-		switch e.Type {
-		case "item":
-			itemIDs = append(itemIDs, e.ID)
-		case "container":
-			containerIDs = append(containerIDs, e.ID)
-		}
-	}
-	return
-}
-
 // HandleBulkMove handles POST /ui/actions/bulk/move.
 func (s *Server) HandleBulkMove(w http.ResponseWriter, r *http.Request) {
-	var req bulkMoveRequest
+	var req dto.BulkMoveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	errs, err := s.bulk.Move(itemIDs, containerIDs, req.TargetContainerID)
 	if err != nil {
 		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -61,13 +31,13 @@ func (s *Server) HandleBulkMove(w http.ResponseWriter, r *http.Request) {
 
 // HandleBulkDelete handles POST /ui/actions/bulk/delete.
 func (s *Server) HandleBulkDelete(w http.ResponseWriter, r *http.Request) {
-	var req bulkDeleteRequest
+	var req dto.BulkDeleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	deleted, errs, err := s.bulk.Delete(itemIDs, containerIDs)
 	if err != nil {
 		webutil.JSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -82,13 +52,13 @@ func (s *Server) HandleBulkDelete(w http.ResponseWriter, r *http.Request) {
 
 // HandleBulkTags handles POST /ui/actions/bulk/tags.
 func (s *Server) HandleBulkTags(w http.ResponseWriter, r *http.Request) {
-	var req bulkTagsRequest
+	var req dto.BulkTagsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
 		return
 	}
 
-	itemIDs, containerIDs := splitBulkIDs(req.IDs)
+	itemIDs, containerIDs := dto.SplitBulkIDs(req.IDs)
 	if err := s.bulk.AddTag(itemIDs, containerIDs, req.TagID); err != nil {
 		webutil.JSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -80,6 +80,20 @@ type TagTreeData struct {
 	Path   []store.Tag
 }
 
+// ContainerFormData is the view model for the container create/edit form.
+type ContainerFormData struct {
+	Container *store.Container
+	Path      []store.Container
+	ParentID  string
+}
+
+// ItemFormData is the view model for the item create/edit form.
+type ItemFormData struct {
+	Item        *store.Item
+	Path        []store.Container
+	ContainerID string
+}
+
 type SearchResultsData struct {
 	Query      string
 	Containers []store.Container
@@ -231,6 +245,8 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui", s.HandleRoot)
 	mux.HandleFunc("GET /ui/containers/{id}", s.HandleContainer)
 	mux.HandleFunc("GET /ui/items/{id}", s.HandleItem)
+	mux.HandleFunc("GET /ui/containers/{id}/edit", s.HandleContainerEdit)
+	mux.HandleFunc("GET /ui/items/{id}/edit", s.HandleItemEdit)
 
 	mux.HandleFunc("POST /ui/actions/containers", s.HandleContainerCreate)
 	mux.HandleFunc("PUT /ui/actions/containers/{id}", s.HandleContainerUpdate)


### PR DESCRIPTION
## Summary

Addresses issues #33, #42, #43, and #45 in a single coordinated refactoring:

- **#33 — Shared bulk types**: Extracted duplicated `bulkIDEntry`, `bulkMoveRequest`, `bulkDeleteRequest`, `bulkTagsRequest` structs and `splitBulkIDs()` from both `api/handlers_bulk.go` and `ui/handlers_bulk.go` into `internal/shared/dto/bulk.go`
- **#42 — Input validation**: Added `internal/shared/validate/` package with `Name()` and `OptionalText()` validators (max length, control char checks). Integrated at service layer for containers, items, and tags. Removed manual `TrimSpace` checks from handlers
- **#43 — Partitioned store**: Replaced monolithic `data.json` with per-collection JSON files (`containers.json`, `items.json`, etc.) using dirty tracking bitfield — only modified collections are written on `Save()`. Automatic migration from legacy format with backup
- **#45 — Edit UX**: Added `GET /ui/containers/{id}/edit` and `GET /ui/items/{id}/edit` routes wiring existing form templates. Fixed broken edit link on item detail page. Added edit button on container header. Extended `UpdateItem` to accept quantity parameter. Added quantity field to item edit form

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go test ./...` — all packages pass
- [x] `make lint` — 0 issues
- [x] Pre-commit hooks (gofmt, govet, golangci-lint, conventional commit) — all pass
- [ ] Manual: create container → edit name/description → verify persistence
- [ ] Manual: create item → edit quantity via edit form → verify persistence after restart
- [ ] Manual: verify legacy data.json auto-migrates to partitioned format
- [ ] E2E: navigate to item detail → click Edit → form shows pre-filled → modify → save

Closes #33, closes #42, closes #43, closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)